### PR TITLE
re-frame-simple - add version missing quote

### DIFF
--- a/re-frame-simple/README.md
+++ b/re-frame-simple/README.md
@@ -35,7 +35,7 @@ This project includes **re-frame-trace** so you can see how the events dispatche
 
 Add the dependency (`boot` or `project.clj`):
 
-`[re-view/re-frame-simple "0.1.0]`
+`[re-view/re-frame-simple "0.1.0"]`
 
 Require the namespace:
 


### PR DESCRIPTION
Hi @mhuebert. A tiny change, you can ignore if you want, but I just stumbled on it.  And by the way, I like the "idioms" proposed by `re-frame-simple`. Nice!