### PR TITLE
Missing square bracket in re-db README.md

### DIFF
--- a/re_db/README.md
+++ b/re_db/README.md
@@ -18,7 +18,7 @@ It is normal to use just one re-db namespace, `re-db.d`, for reads and writes th
 
 ```clj
 (ns my-app.core
-  (:require [re-db.d :as d))
+  (:require [re-db.d :as d]))
 ```
 
 ### Writing data


### PR DESCRIPTION
I found a lonely square bracket looking for its peer, they are now reunited :bowtie: 